### PR TITLE
Made file hashing asynchronous

### DIFF
--- a/src/artifacts/CircuitArtifacts.ts
+++ b/src/artifacts/CircuitArtifacts.ts
@@ -225,7 +225,7 @@ export class CircuitArtifacts implements ICircuitArtifacts {
 
         circuitArtifact.compilerOutputFiles[CircuitArtifacts.getArtifactOutputFileKey(fileType, provingSystem)] = {
           fileSourcePath,
-          fileHash: getFileHash(fileSourcePath),
+          fileHash: await getFileHash(fileSourcePath),
         };
       }
     }

--- a/src/core/dependencies/CircomFilesResolver.ts
+++ b/src/core/dependencies/CircomFilesResolver.ts
@@ -19,7 +19,7 @@ import { getRealPath } from "hardhat/internal/util/fs-utils";
 
 import { CircomFilesParser } from "./parser/CircomFilesParser";
 import { CIRCOM_FILE_REG_EXP, NODE_MODULES, NODE_MODULES_REG_EXP, URI_SCHEME_REG_EXP } from "../../constants";
-import { getSHA256Hash } from "../../utils";
+import { getSHA1Hash } from "../../utils";
 import { HardhatZKitError } from "../../errors";
 
 import {
@@ -385,7 +385,8 @@ export class CircomFilesResolver {
     const stats = await fsExtra.stat(absolutePath);
     const lastModificationDate = new Date(stats.ctime);
 
-    const contentHash = getSHA256Hash(rawContent);
+    // Add await here
+    const contentHash = await getSHA1Hash(fsExtra.readFileSync(absolutePath));
 
     const fileData = this._parser.parse(rawContent, absolutePath, contentHash);
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -103,14 +103,19 @@ export async function execCall(execFile: string, callArgs: string[]): Promise<Ex
   });
 }
 
-export function getFileHash(filePath: string): string {
-  return getSHA256Hash(fsExtra.readFileSync(filePath, "utf-8"));
+export async function getFileHash(filePath: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const hash = createHash("sha1");
+    const stream = fsExtra.createReadStream(filePath);
+
+    stream.on("data", (data) => hash.update(data));
+    stream.on("end", () => resolve(hash.digest("hex")));
+    stream.on("error", reject);
+  });
 }
 
-export function getSHA256Hash(rawFileData: string): string {
-  const fileData: Buffer = Buffer.from(rawFileData);
-
-  return createHash("sha1").update(fileData).digest().toString("hex");
+export function getSHA1Hash(rawFileData: Buffer): string {
+  return createHash("sha1").update(rawFileData).digest().toString("hex");
 }
 
 export function getUniqueProvingSystems(provingSystems: ProvingSystemType | ProvingSystemType[]): ProvingSystemType[] {

--- a/test/unit/cache/circuits-compile-cache.test.ts
+++ b/test/unit/cache/circuits-compile-cache.test.ts
@@ -94,7 +94,7 @@ describe("CircuitsCompileCache", () => {
       expect(CircuitsCompileCache!.hasFileChanged("invalid-path", "", defaultCompileFlags)).to.be.true;
 
       const circuitPath = getNormalizedFullPath(this.hre.config.paths.root, "circuits/main/mul2.circom");
-      const contentHash = getFileHash(circuitPath);
+      const contentHash = await getFileHash(circuitPath);
 
       expect(CircuitsCompileCache!.hasFileChanged(circuitPath, contentHash + "1", defaultCompileFlags)).to.be.true;
       expect(CircuitsCompileCache!.hasFileChanged(circuitPath, contentHash, { ...defaultCompileFlags, c: true })).to.be

--- a/test/unit/cache/circuits-setup-cache.test.ts
+++ b/test/unit/cache/circuits-setup-cache.test.ts
@@ -105,7 +105,7 @@ describe("CircuitsSetupCache", () => {
         "r1cs",
       );
 
-      const contentHash = getFileHash(mul2R1CSFilePath);
+      const contentHash = await getFileHash(mul2R1CSFilePath);
 
       expect(
         CircuitsSetupCache!.hasFileChanged(mul2ArtifactFullPath, contentHash + "1", defaultContributionSettings),


### PR DESCRIPTION
---
BUG FIX
---

Node.js has a limitation where it can't handle files larger than 2GB with synchronous file operations.
Made file hashing asynchronous.
