### PR TITLE
Typo Update index.ts **minor change**

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -380,7 +380,7 @@ zkitScope
   )
   .addOptionalParam(
     "verifiersType",
-    "Verifier contracts laguage to generate. Use 'sol' for Solidity and 'vy' for Vyper",
+    "Verifier contracts language to generate. Use 'sol' for Solidity and 'vy' for Vyper",
     undefined,
     types.string,
   )


### PR DESCRIPTION
- [ ] Since this PR suggests a **bug fix**, the relevant tests have been added.
- [ ] Since this PR introduces a **new feature**, the update has been discussed in an Issue or with the team.
- [x] This PR is just a **minor change**, like a typo fix.

**Description:**

I noticed a potential issue in the code where a typo was present in the description of the `"verifiersType"` parameter. Specifically, the word `"laguage"` was used instead of the correct spelling `"language"`. This was just a grammatical mistake in the comment.

The original code:
```ts
.addOptionalParam(
  "verifiersType",
  "Verifier contracts laguage to generate. Use 'sol' for Solidity and 'vy' for Vyper",
  undefined,
  types.string,
)
```

The corrected version:
```ts
.addOptionalParam(
  "verifiersType",
  "Verifier contracts language to generate. Use 'sol' for Solidity and 'vy' for Vyper",
  undefined,
  types.string,
)
```

**Importance:**

This change is important because the typo could cause confusion for developers reading the code. Ensuring that the comments are clear and grammatically correct improves the readability and professionalism of the codebase, particularly for developers unfamiliar with the project. While this was a minor typo, it's important to maintain consistency and clarity throughout the documentation.