### PR TITLE
Typo Update path-utils.ts **minor change**

### DIFF
--- a/src/utils/path-utils.ts
+++ b/src/utils/path-utils.ts
@@ -85,7 +85,7 @@ export function filterCircuitFiles<T>(
     const circuitFullPath: string = getCircuitPath(circuitInfo);
 
     return (
-      (filterSettings.onlyFiles.length == 0 || contains(circuitsRoot, filterSettings.onlyFiles, circuitFullPath)) &&
+      (filterSettings.onlyFiles.length === 0 || contains(circuitsRoot, filterSettings.onlyFiles, circuitFullPath)) &&
       !contains(circuitsRoot, filterSettings.skipFiles, circuitFullPath)
     );
   });


### PR DESCRIPTION
- [ ] Since this PR suggests a **bug fix**, the relevant tests have been added.
- [ ] Since this PR introduces a **new feature**, the update has been discussed in an Issue or with the team.
- [x] This PR is just a **minor change**, like a typo fix.

### Description:
This pull request fixes the comparison in the following line:

```typescript
filterSettings.onlyFiles.length == 0
```

The issue was that it was using loose equality (`==`), which in JavaScript and TypeScript can lead to unexpected behavior when comparing values of different types (e.g., a string and a number). For instance, `"" == 0` would return `true` due to type coercion, which could result in bugs that are hard to detect and fix.

### Change:
The code has been updated to use strict equality (`===`), which ensures that both the type and value are compared, preventing any unintended type coercion:

```typescript
filterSettings.onlyFiles.length === 0
```

### Importance:
Using strict equality (`===`) is more idiomatic in JavaScript and TypeScript. It ensures that the comparison is type-safe and helps avoid potential issues that could arise from unexpected type conversions. This change improves code clarity and reduces the risk of errors, especially in complex logic where type coercion might not be expected.

By using strict equality, we ensure that the code is more predictable and easier to maintain, as it avoids subtle bugs caused by type coercion.

