### PR TITLE
Fix Typos in CompilationProcessor.ts, compilation-processor.ts, and file-parser.test.ts

### DIFF
--- a/src/core/compile/CompilationProcessor.ts
+++ b/src/core/compile/CompilationProcessor.ts
@@ -23,7 +23,7 @@ import { ZKitConfig } from "../../types/zkit-config";
 import { ArtifactsFileType, CircuitArtifact, ICircuitArtifacts } from "../../types/artifacts/circuit-artifacts";
 import {
   ICircomCompiler,
-  CompilationProccessorConfig,
+  CompilationProcessorConfig,
   CompilationInfo,
   CompileConfig,
   CircomResolvedFileInfo,
@@ -43,7 +43,7 @@ export class CompilationProcessor {
   private readonly _nodeModulesPath: string;
 
   constructor(
-    private readonly _config: CompilationProccessorConfig,
+    private readonly _config: CompilationProcessorConfig,
     private readonly _circuitArtifacts: ICircuitArtifacts,
     hre: HardhatRuntimeEnvironment,
   ) {

--- a/src/types/core/compile/compilation-processor.ts
+++ b/src/types/core/compile/compilation-processor.ts
@@ -1,7 +1,7 @@
 import { CompileFlags } from "../compiler/circom-compiler";
 import { CircomResolvedFile } from "../dependencies";
 
-export type CompilationProccessorConfig = {
+export type CompilationProcessorConfig = {
   compileFlags: CompileFlags;
   quiet: boolean;
 };

--- a/test/unit/core/dependencies/file-parser.test.ts
+++ b/test/unit/core/dependencies/file-parser.test.ts
@@ -47,7 +47,7 @@ describe("CircomFilesParser", () => {
       expect(result.parsedFileData.pragmaInfo.compilerVersion).to.be.eq("2.0.0");
     });
 
-    it("should correctly parse circuit file content wihout cache", async function () {
+    it("should correctly parse circuit file content without cache", async function () {
       fs.rmSync(circuitsCacheFullPath, { force: true });
 
       const result: ResolvedFileData = parser.parse(fileContent, circuitPath, contentHash);


### PR DESCRIPTION
- **CompilationProcessor.ts**: Corrected "CompilationProccessorConfig" to "CompilationProcessorConfig."
- **compilation-processor.ts**: Corrected "CompilationProccessorConfig" to "CompilationProcessorConfig."
- **file-parser.test.ts**: Corrected "wihout" to "without."

---

- [x] This PR is just a **minor change**, like a typo fix.
