### PR TITLE
refactor: replace manual directory and file checks with fs-extra methods

### DIFF
--- a/src/core/compile/CompilationProcessor.ts
+++ b/src/core/compile/CompilationProcessor.ts
@@ -225,13 +225,8 @@ export class CompilationProcessor {
         const correspondingOutDir = path.join(info.artifactsPath, path.relative(info.tempArtifactsPath, dir));
         const correspondingOutFile = path.join(info.artifactsPath, path.relative(info.tempArtifactsPath, file));
 
-        if (!fsExtra.existsSync(correspondingOutDir)) {
-          fsExtra.mkdirSync(correspondingOutDir);
-        }
-
-        if (fsExtra.existsSync(correspondingOutFile)) {
-          fsExtra.rmSync(correspondingOutFile);
-        }
+        fsExtra.ensureDirSync(correspondingOutDir);
+        fsExtra.removeSync(correspondingOutFile);
 
         Reporter!.verboseLog("compilation-processor:copying", "Copying file from temp directory to artifacts: %o", [
           { file, correspondingOutFile },


### PR DESCRIPTION

This PR refactors the code to use fs-extra convenience methods for directory and file operations. Specifically:

- Replaced manual checks with fsExtra.ensureDirSync for directory creation.
- Replaced manual checks with fsExtra.removeSync for file removal.
- Simplified the code, making it more readable and maintainable.

This is a minor change that improves code quality without introducing new functionality or fixing a bug.


