### PR TITLE
Update checkout action to v4 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up environment
         uses: ./.github/actions/setup
       - name: Fetch State
@@ -32,7 +32,7 @@ jobs:
     if: needs.state.outputs.version_changed != 'not_changed'
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
@@ -54,7 +54,7 @@ jobs:
     if: needs.state.outputs.version_changed != 'not_changed'
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup
         uses: ./.github/actions/setup
       - name: Publish to npm

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
           - 20
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
Updated actions/checkout from v3 to v4


Migration guide for v4:
[ actions/upload-artifact/docs/MIGRATION.md](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md)

Recommended to avoid missing out on latest performance and security improvements.