### PR TITLE
Update actions/setup-node to v4

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,7 +4,7 @@ runs:
   using: composite
   steps:
     - name: Setup node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: "18.18.x"
         cache: npm


### PR DESCRIPTION
Replaced actions/setup-node@v3 with @v4 to use the latest stable version.
Includes performance improvements, updated caching, and better compatibility with modern tooling.

Reference: [setup-node v4 release](https://github.com/actions/setup-node/releases)
