### PR TITLE
ci: bump actions/checkout to v6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Set up environment
         uses: ./.github/actions/setup
       - name: Fetch State
@@ -32,7 +32,7 @@ jobs:
     if: needs.state.outputs.version_changed != 'not_changed'
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
@@ -54,7 +54,7 @@ jobs:
     if: needs.state.outputs.version_changed != 'not_changed'
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Setup
         uses: ./.github/actions/setup
       - name: Publish to npm

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
           - 22
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
Upgrade to actions/checkout v6 for latest improvements and security fixes.

https://github.com/actions/checkout/releases/tag/v6.0.0